### PR TITLE
Fix overflow to be auto instead of scroll

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -39,7 +39,7 @@ body {
     padding-left: 40px;
     padding-right: 40px;
 		padding-bottom: 0;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
   }
 }

--- a/public/css/code.css
+++ b/public/css/code.css
@@ -17,7 +17,7 @@ p code {
 
 pre code {
 	text-wrap: nowrap !important;
-	overflow-x: scroll !important;
+	overflow-x: auto !important;
 	display: block;
 	padding: 10px 10px;
 	margin: 0 0 0 0;

--- a/public/css/entry.css
+++ b/public/css/entry.css
@@ -10,7 +10,7 @@
 
   @media screen and (min-width: 800px) {
    min-width: var(--entry-max-width);
-   overflow: scroll;
+   overflow: auto;
    margin-bottom: 0;
    height: max-content;
    max-height: 78dvh;

--- a/public/css/header.css
+++ b/public/css/header.css
@@ -100,7 +100,7 @@ menu-btn button {
 	top: 60px;
 	bottom: 0;
 	width: 100%;
-	overflow: scroll;
+	overflow: auto;
 	animation: 400ms roll-out ease-out forwards;
 	-webkit-backdrop-filter: blur(60px);
 	backdrop-filter: blur(60px);


### PR DESCRIPTION
There is rarely a good reason to use the `scroll` value of `overflow` — it should be `auto` instead, otherwise in systems with always visible non-overlay scrollbars there will be unnecessary placeholders.

Example from https://csscade.com/in-defense-of-asymmetric-grids/ :

<img width="847" alt="A screenshot of the csscade.com post with a vew empty scrollbars visible" src="https://github.com/robinrendle/cascade/assets/177485/777dccd4-2bb5-417a-907e-71978b03ad40">

There are three visible places where this happens in this screenshot:

1. The bottom scrollbar placeholder for the whole page.
2. The bottom scrollbar placeholder for the content area.
3. The bottom scrollbar placeholder for the `code` element.

See also my post [“Never Use ‘Scroll’ Value for Overflow”](https://blog.kizu.dev/never-use-overflow-scroll/ )
